### PR TITLE
Allow generating docs for modified typedoc reflections tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ const removeTrailingSlash = (pathString = '') =>
 export default async function initAstroTypedoc({
   baseUrl = '/docs/',
   entryPoints,
-  pagesDirectory = 'src/pages/docs',
   tsconfig
 }) {
   let app = await Application.bootstrapWithPlugins({
@@ -83,7 +82,7 @@ export default async function initAstroTypedoc({
   app.renderer.on(PageEvent.END, event => onRendererPageEnd(event))
 
   let getReflections = async () => await app.convert()
-  let generateDocs = async project =>
+  let generateDocs = async (project, pagesDirectory = 'src/pages/docs') =>
     await app.generateDocs(project, pagesDirectory)
   let generateNavigationJSON = async (project, outputFolder) => {
     let navigation = getNavigationFromProject(baseUrl, project)

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { Application, PageEvent, TSConfigReader } from 'typedoc'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-function onRendererPageEnd(event) {
+const onRendererPageEnd = event => {
   if (!event.contents) {
     return
   } else if (/README\.md$/.test(event.url)) {
@@ -23,7 +23,7 @@ layout: '../../../layouts/DocLayout.astro'
   event.contents = frontmatter + event.contents
 }
 
-function getNavigationFromProject(baseUrl = '', project) {
+const getNavigationFromProject = (baseUrl = '', project) => {
   let baseUrlWithoutTrailingSlash = baseUrl.replace(/\/$/gm, '')
 
   let nav = project?.groups
@@ -62,11 +62,11 @@ const removeTrailingSlash = (pathString = '') =>
     ? pathString.slice(0, pathString.length - 1)
     : pathString
 
-export default async function initAstroTypedoc({
+export const initAstroTypedoc = async ({
   baseUrl = '/docs/',
   entryPoints,
   tsconfig
-}) {
+}) => {
   let app = await Application.bootstrapWithPlugins({
     ...typedocConfig,
     ...markdownPluginConfig,
@@ -99,3 +99,5 @@ export default async function initAstroTypedoc({
     getReflections
   }
 }
+
+export default initAstroTypedoc

--- a/test/website-nanostores/astro.config.mjs
+++ b/test/website-nanostores/astro.config.mjs
@@ -9,13 +9,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const astroTypedoc = await initAstroTypedoc({
   baseUrl: '/docs/',
   entryPoints: [resolve(__dirname, '../../../nanostores/index.d.ts')],
-  pagesDirectory: 'src/pages/docs',
   tsconfig: resolve(__dirname, '../../../nanostores/tsconfig.json')
 })
 
 const reflections = await astroTypedoc.getReflections()
 
-await astroTypedoc.generateDocs(reflections)
+await astroTypedoc.generateDocs(reflections, 'src/pages/docs')
 await astroTypedoc.generateNavigationJSON(
   reflections,
   resolve(__dirname, './src/')

--- a/test/website-nanostores/astro.config.mjs
+++ b/test/website-nanostores/astro.config.mjs
@@ -2,16 +2,24 @@ import { defineConfig } from 'astro/config'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'url'
 
-import { generateApiDocs } from '../../index.js'
+import initAstroTypedoc from '../../index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-await generateApiDocs({
+const astroTypedoc = await initAstroTypedoc({
   baseUrl: '/docs/',
   entryPoints: [resolve(__dirname, '../../../nanostores/index.d.ts')],
   pagesDirectory: 'src/pages/docs',
   tsconfig: resolve(__dirname, '../../../nanostores/tsconfig.json')
 })
+
+const reflections = await astroTypedoc.getReflections()
+
+await astroTypedoc.generateDocs(reflections)
+await astroTypedoc.generateNavigationJSON(
+  reflections,
+  resolve(__dirname, './src/')
+)
 
 // https://astro.build/config
 export default defineConfig({})

--- a/test/website-types/astro.config.mjs
+++ b/test/website-types/astro.config.mjs
@@ -2,14 +2,24 @@ import { defineConfig } from 'astro/config'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { generateApiDocs } from '../../index.js'
+import initAstroTypedoc from '../../index.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-await generateApiDocs({
+const astroTypedoc = await initAstroTypedoc({
+  baseUrl: '/docs/',
   entryPoints: [resolve(__dirname, '../types/index.ts')],
+  pagesDirectory: 'src/pages/docs',
   tsconfig: resolve(__dirname, '../types/tsconfig.json')
 })
+
+const reflections = await astroTypedoc.getReflections()
+
+await astroTypedoc.generateDocs(reflections)
+await astroTypedoc.generateNavigationJSON(
+  reflections,
+  resolve(__dirname, './src/')
+)
 
 // https://astro.build/config
 export default defineConfig({})

--- a/test/website-types/astro.config.mjs
+++ b/test/website-types/astro.config.mjs
@@ -9,13 +9,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const astroTypedoc = await initAstroTypedoc({
   baseUrl: '/docs/',
   entryPoints: [resolve(__dirname, '../types/index.ts')],
-  pagesDirectory: 'src/pages/docs',
   tsconfig: resolve(__dirname, '../types/tsconfig.json')
 })
 
 const reflections = await astroTypedoc.getReflections()
 
-await astroTypedoc.generateDocs(reflections)
+await astroTypedoc.generateDocs(reflections, 'src/pages/docs')
 await astroTypedoc.generateNavigationJSON(
   reflections,
   resolve(__dirname, './src/')

--- a/test/website-types/src/components/Sidebar.astro
+++ b/test/website-types/src/components/Sidebar.astro
@@ -1,0 +1,19 @@
+---
+import nav from '../nav.json'
+---
+
+{
+  nav?.length && (
+    <nav class="navigation">
+      {nav.map(item => {
+        return <a href={item.url}>{item.title}</a>
+      })}
+    </nav>
+  )
+}
+<style>
+  .navigation {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/test/website-types/src/layouts/DocLayout.astro
+++ b/test/website-types/src/layouts/DocLayout.astro
@@ -1,0 +1,32 @@
+---
+import Sidebar from '../components/Sidebar.astro'
+
+const { frontmatter } = Astro.props
+const { title } = frontmatter
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <div class="layout">
+      <Sidebar />
+      <main>
+        <h1>{title}</h1>
+        <article>
+          <slot />
+        </article>
+      </main>
+    </div>
+  </body>
+</html>
+
+<style>
+  .layout {
+    display: grid;
+    grid-template-columns: 25% 75%;
+  }
+</style>

--- a/test/website-types/src/pages/index.astro
+++ b/test/website-types/src/pages/index.astro
@@ -1,15 +1,17 @@
 ---
+import Sidebar from '../components/Sidebar.astro'
 ---
 
 <html lang="en">
-	<head>
-		<meta charset="utf-8" />
-		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-		<meta name="viewport" content="width=device-width" />
-		<meta name="generator" content={Astro.generator} />
-		<title>Astro</title>
-	</head>
-	<body>
-		<h1>Astro</h1>
-	</body>
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Astro</title>
+  </head>
+  <body>
+    <h1>Types stub project</h1>
+    <Sidebar />
+  </body>
 </html>


### PR DESCRIPTION
This PR splits the process of docs generating into the following steps:

- get reflections tree
- generate pages
- generate navigation JSON