### PR TITLE
Edit navigation format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 
 test/website-*/src/pages/docs/**/*
 test/website-*/src/nav.json
+tsconfig.generic.json

--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ There are 3 subfolders is `test/` folder.
 3. `website-nanostores` - a sample site which is generated from `nanostores` package.
    [`nanostores`](https://github.com/nanostores/nanostores) repository needs to be cloned locally.
 
+   [`@nanostores/router`](https://github.com/nanostores/router) respository needs to be cloned locally.
+
    Folder structure should look like this:
 
    ```
    .
    ├── astro-typedoc
+   ├── router
    └── nanostores
    ```
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,12 @@ importers:
         specifier: ^2.10.14
         version: 2.10.14
 
+  test/website-nanostores-multiple-ep:
+    dependencies:
+      astro:
+        specifier: ^2.10.14
+        version: 2.10.14
+
   test/website-types:
     dependencies:
       astro:
@@ -1340,7 +1346,7 @@ packages:
       kleur: 4.1.5
       magic-string: 0.30.3
       mime: 3.0.0
-      network-information-types: 0.1.1(typescript@5.1.6)
+      network-information-types: 0.1.1(typescript@5.2.2)
       ora: 6.3.1
       p-limit: 4.0.0
       path-to-regexp: 6.2.1
@@ -1353,7 +1359,7 @@ packages:
       string-width: 5.1.2
       strip-ansi: 7.1.0
       tsconfig-resolver: 3.0.1
-      typescript: 5.1.6
+      typescript: 5.2.2
       unist-util-visit: 4.1.2
       vfile: 5.3.7
       vite: 4.4.9
@@ -3382,12 +3388,12 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /network-information-types@0.1.1(typescript@5.1.6):
+  /network-information-types@0.1.1(typescript@5.2.2):
     resolution: {integrity: sha512-mLXNafJYOkiJB6IlF727YWssTRpXitR+tKSLyA5VAdBi3SOvLf5gtizHgxf241YHPWocnAO/fAhVrB/68tPHDw==}
     peerDependencies:
       typescript: '>= 3.0.0'
     dependencies:
-      typescript: 5.1.6
+      typescript: 5.2.2
 
   /nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
@@ -4226,11 +4232,6 @@ packages:
       shiki: 0.14.3
       typescript: 5.2.2
     dev: false
-
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   /typescript@5.2.2:
     resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,5 @@ packages:
   - 'test/website-types'
   # Astro site for nanostores project
   - 'test/website-nanostores'
+  # Astro site for nanostores project (multiple entrypoints)
+  - 'test/website-nanostores-multiple-ep'

--- a/test/website-nanostores-multiple-ep/.gitignore
+++ b/test/website-nanostores-multiple-ep/.gitignore
@@ -1,0 +1,15 @@
+# build output
+dist/
+# generated types
+.astro/
+
+# dependencies
+node_modules/
+
+# logs
+pnpm-debug.log*
+
+
+# environment variables
+.env
+.env.production

--- a/test/website-nanostores-multiple-ep/README.md
+++ b/test/website-nanostores-multiple-ep/README.md
@@ -2,11 +2,16 @@ This site is generated from `nanostores` codebase types.
 
 ## `nanstores` repo is needed
 
-To make it work please make sure you have cloned [`nanostores`](https://github.com/nanostores/nanostores)
-repo locally, and follow folder structure:
+To make it work please make sure you have cloned following repos locally:
+
+- [`nanostores`](https://github.com/nanostores/nanostores)
+- [`@nanostores/router`](https://github.com/nanostores/router)
+
+and follow folder structure:
 
 ```
 .
 ├── astro-typedoc
+├── router
 └── nanostores
 ```

--- a/test/website-nanostores-multiple-ep/README.md
+++ b/test/website-nanostores-multiple-ep/README.md
@@ -1,0 +1,12 @@
+This site is generated from `nanostores` codebase types.
+
+## `nanstores` repo is needed
+
+To make it work please make sure you have cloned [`nanostores`](https://github.com/nanostores/nanostores)
+repo locally, and follow folder structure:
+
+```
+.
+├── astro-typedoc
+└── nanostores
+```

--- a/test/website-nanostores-multiple-ep/astro.config.mjs
+++ b/test/website-nanostores-multiple-ep/astro.config.mjs
@@ -9,10 +9,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const astroTypedoc = await initAstroTypedoc({
   baseUrl: '/docs/',
   entryPoints: [
-    resolve(__dirname, '../../../nanostores/action/index.d.ts'),
-    resolve(__dirname, '../../../nanostores/atom/index.d.ts')
-  ],
-  tsconfig: resolve(__dirname, '../../../nanostores/tsconfig.json')
+    resolve(__dirname, '../../../nanostores/index.d.ts'),
+    resolve(__dirname, '../../../router/index.d.ts')
+  ]
 })
 
 const project = await astroTypedoc.getReflections()

--- a/test/website-nanostores-multiple-ep/astro.config.mjs
+++ b/test/website-nanostores-multiple-ep/astro.config.mjs
@@ -1,0 +1,30 @@
+import { defineConfig } from 'astro/config'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import initAstroTypedoc from '../../index.js'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const astroTypedoc = await initAstroTypedoc({
+  baseUrl: '/docs/',
+  entryPoints: [
+    resolve(__dirname, '../../../nanostores/action/index.d.ts'),
+    resolve(__dirname, '../../../nanostores/atom/index.d.ts')
+  ],
+  tsconfig: resolve(__dirname, '../../../nanostores/tsconfig.json')
+})
+
+const project = await astroTypedoc.getReflections()
+
+await astroTypedoc.generateDocs({
+  frontmatter: {
+    layout: resolve(__dirname, './src/layouts/DocLayout.astro')
+  },
+  outputFolder: 'src/pages/docs',
+  project
+})
+await astroTypedoc.generateNavigationJSON(project, resolve(__dirname, './src/'))
+
+// https://astro.build/config
+export default defineConfig({})

--- a/test/website-nanostores-multiple-ep/package.json
+++ b/test/website-nanostores-multiple-ep/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "website-nanostores",
+  "type": "module",
+  "version": "0.0.1",
+  "scripts": {
+    "dev": "astro dev",
+    "start": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "astro": "astro"
+  },
+  "dependencies": {
+    "astro": "^2.10.14"
+  }
+}

--- a/test/website-nanostores-multiple-ep/src/components/Sidebar.astro
+++ b/test/website-nanostores-multiple-ep/src/components/Sidebar.astro
@@ -3,11 +3,18 @@ import nav from '../nav.json'
 ---
 
 {
-  nav?.length && (
+  nav?.modules.length && (
     <nav class="navigation">
-      {nav.map(item => {
-        return <a href={item.url}>{item.title}</a>
-      })}
+      {nav.modules.map(mod => (
+        <div>
+          Module: {mod.name} <br />
+          {mod.items.map(modItem => (
+            <div>
+              <a href={modItem.url}>{modItem.title} </a>
+            </div>
+          ))}
+        </div>
+      ))}
     </nav>
   )
 }

--- a/test/website-nanostores-multiple-ep/src/components/Sidebar.astro
+++ b/test/website-nanostores-multiple-ep/src/components/Sidebar.astro
@@ -1,0 +1,19 @@
+---
+import nav from '../nav.json'
+---
+
+{
+  nav?.length && (
+    <nav class="navigation">
+      {nav.map(item => {
+        return <a href={item.url}>{item.title}</a>
+      })}
+    </nav>
+  )
+}
+<style>
+  .navigation {
+    display: flex;
+    flex-direction: column;
+  }
+</style>

--- a/test/website-nanostores-multiple-ep/src/env.d.ts
+++ b/test/website-nanostores-multiple-ep/src/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference path="../.astro/types.d.ts" />
+/// <reference types="astro/client" />

--- a/test/website-nanostores-multiple-ep/src/layouts/DocLayout.astro
+++ b/test/website-nanostores-multiple-ep/src/layouts/DocLayout.astro
@@ -1,0 +1,32 @@
+---
+import Sidebar from '../components/Sidebar.astro'
+
+const { frontmatter } = Astro.props
+const { title } = frontmatter
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <div class="layout">
+      <Sidebar />
+      <main>
+        <h1>{title}</h1>
+        <article>
+          <slot />
+        </article>
+      </main>
+    </div>
+  </body>
+</html>
+
+<style>
+  .layout {
+    display: grid;
+    grid-template-columns: 25% 75%;
+  }
+</style>

--- a/test/website-nanostores-multiple-ep/src/pages/index.astro
+++ b/test/website-nanostores-multiple-ep/src/pages/index.astro
@@ -1,0 +1,17 @@
+---
+import Sidebar from '../components/Sidebar.astro'
+---
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="generator" content={Astro.generator} />
+    <title>Astro</title>
+  </head>
+  <body>
+    <h1>Nanostores</h1>
+    <Sidebar />
+  </body>
+</html>

--- a/test/website-nanostores-multiple-ep/tsconfig.json
+++ b/test/website-nanostores-multiple-ep/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "astro/tsconfigs/base"
+}

--- a/test/website-nanostores/src/components/Sidebar.astro
+++ b/test/website-nanostores/src/components/Sidebar.astro
@@ -3,9 +3,9 @@ import nav from '../nav.json'
 ---
 
 {
-  nav?.length && (
+  nav?.items?.length && (
     <nav class="navigation">
-      {nav.map(item => {
+      {nav.items.map(item => {
         return <a href={item.url}>{item.title}</a>
       })}
     </nav>

--- a/test/website-types/src/components/Sidebar.astro
+++ b/test/website-types/src/components/Sidebar.astro
@@ -3,9 +3,9 @@ import nav from '../nav.json'
 ---
 
 {
-  nav?.length && (
+  nav?.items?.length && (
     <nav class="navigation">
-      {nav.map(item => {
+      {nav.items.map(item => {
         return <a href={item.url}>{item.title}</a>
       })}
     </nav>


### PR DESCRIPTION
This one changes navigation format to new one that described in https://github.com/evilmartians/astro-typedoc/issues/25#issuecomment-1713743440

Added new test environment -- project with multiple entry points.

Also changed templates. 
Now navigation looks the same as before for single entry point, but for multiple entries it looks like this:

![image](https://github.com/evilmartians/astro-typedoc/assets/35267898/ccdcf791-7fbf-4381-919e-c1258f819181)
