### PR TITLE
Fix cross project reference links

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,16 @@ export const initAstroTypedoc = async ({ baseUrl = '/docs/', entryPoints }) => {
   await writeFile(
     resolve(__dirname, './tsconfig.generic.json'),
     JSON.stringify({
+      compilerOptions: {
+        baseUrl: '.',
+        paths: entryPoints.reduce((paths, { name, path }) => {
+          if (name) {
+            paths[name] = [path]
+          }
+
+          return paths
+        }, {})
+      },
       include: entryPoints.map(e => e.path)
     })
   )


### PR DESCRIPTION
This one adds support for cross-project links.
It's a bit hackish, but still seems to be working fine.
The idea is to make TypeDoc treat external packages as internal by providing `paths` option to generic tsconfig.

Demo before changes:

https://github.com/evilmartians/astro-typedoc/assets/35267898/70705006-480c-4834-983b-f34b06f4b09e

Demo after changes:

https://github.com/evilmartians/astro-typedoc/assets/35267898/8436e8f2-e27d-46ce-9199-f44c11bcae4b
